### PR TITLE
Add PHP 5.4 as `RECOMMENDED_VERSION`

### DIFF
--- a/application/controllers/AdminController.php
+++ b/application/controllers/AdminController.php
@@ -316,6 +316,16 @@ class AdminController extends Zend_Controller_Action
     {
         $this->view->headTitle()->append("Update");
 
+        if (SpamFilter_Core::isRestrictedToFrozenTier()) {
+            $this->_flashMessenger->addMessage(array(
+                'message' => sprintf(
+                    $this->t->_('You are running an old PHP version (%s) no longer actively supported by this addon so only the \'frozen\' update tier is available, for critical bugfixes. It is highly recommended to upgrade to a newer PHP version (>=%s) to have access to all the latest features.'),
+                    phpversion(), SpamFilter_Core::PHP5_RECOMMENDED_VERSION
+                ),
+                'status' => 'notice'
+            ));
+        }
+
         if (!$this->_acl->isAllowed('update')) {
             $this->_flashMessenger->addMessage(
                 array('message' => $this->t->_('You do not have permission to this part of the system.'), 'status' => 'error')

--- a/bin/installer/installer.sh
+++ b/bin/installer/installer.sh
@@ -14,6 +14,9 @@ if [ -z "$path_wget" ]; then
     exit 1
 fi
 
+REQUIRED_VERSION=5.2.1
+RECOMMENDED_VERSION=5.4
+
 function version {
     echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
 }
@@ -26,21 +29,25 @@ function check_php_version {
         echo "$1: invalid PHP binary"
         exit 1
     fi
-    REQUIRED_VERSION=5.2.1
     PHPVERSION=`echo "$version_info" | head -n1 | awk {'print $2'} | sed -e 's/-/\n/g' | head -n1`
     if [ -z "$PHPVERSION" ]; then
         echo "$1: PHP version empty"
         exit 1
     fi
 
-    # Check the PHP version against the recommended
-    if [ $(version $PHPVERSION) -ge $(version $REQUIRED_VERSION) ]
-    then
+    # First check the PHP version against the recommended one
+    if [ $(version $PHPVERSION) -ge $(version $RECOMMENDED_VERSION) ]; then
         OPENSSL_SUPPORT=`echo "<?php echo (in_array('https', stream_get_wrappers()) ? 'Y' : 'N');" | $1 -q`
-        if [ 'Y' == "$OPENSSL_SUPPORT" ]
-        then
+        if [ 'Y' == "$OPENSSL_SUPPORT" ]; then
             echo "$1"
             exit 0
+        fi
+    # Then check against the minimum required version
+    elif [ $(version $PHPVERSION) -ge $(version $REQUIRED_VERSION) ]; then
+        OPENSSL_SUPPORT=`echo "<?php echo (in_array('https', stream_get_wrappers()) ? 'Y' : 'N');" | $1 -q`
+        if [ 'Y' == "$OPENSSL_SUPPORT" ]; then
+            echo "$1"
+            exit 255
         fi
     fi
 
@@ -49,18 +56,19 @@ function check_php_version {
 }
 
 function find_php {
-    # We need to find a suitable PHP binary
+    # We need to find and check Plesk's PHP binary, if it exists
     # /opt/psa/admin/bin/php for plesk
-    phpLocations=( "/opt/psa/admin/bin/php" `which php5 2>/dev/null` `which php 2>/dev/null` "/usr/local/bin/prospamfilter_php" )
+    phpLocations=( "/opt/psa/admin/bin/php" "/usr/local/bin/prospamfilter_php" )
     for loc in "${phpLocations[@]}"
     do :
         if [ -e "$loc" ]; then
             PHP_BINARY="$loc"
             $(check_php_version "$PHP_BINARY" > /dev/null 2>&1)
-            if [[ $? -eq 0 ]]; then
-                # Found it, we're done
+            status=$?
+            if [[ $status -eq 0 ]] || [[ $status -eq 255 ]]; then
+                # Found either the recommended version or the minimum required one, so forward the info
                 echo "$PHP_BINARY"
-                exit 0
+                exit $status
             fi
         fi
     done
@@ -69,36 +77,61 @@ function find_php {
     exit 1
 }
 
-php_binary=`find_php`
+BYPASS=false
+while getopts :f FLAG; do
+    case $FLAG in
+        f)  # set "BYPASS" to true
+            BYPASS=true
+            ;;
+    esac
+done
 
-# Request the path to a VALID PHP binary if auto-detect failed
-if [[ -z "$php_binary" || ! -e "$php_binary" || -d "$php_binary" ]]; then
-    echo ""
-    echo -e "\033[31mUnable to detect your PHP binary. Please enter the path to your PHP5 (at least v5.2.1) binary followed by [ENTER]:\033[0m"
-    echo ""
-    read PHP_CUSTOM
+shift $((OPTIND-1))
 
-    while [[ true ]]; do
-        if [[ -z "$PHP_CUSTOM" || ! -e "$PHP_CUSTOM" || -d "$PHP_CUSTOM" ]]; then
-            echo -e "\033[31mPlease enter a valid path to the PHP5 binary:\033[0m"
-            read PHP_CUSTOM
-        else
-            $(check_php_version "$PHP_CUSTOM" > /dev/null 2>&1)
-            if [[ $? -eq 0 ]]; then
-                # Valid PHP_CUSTOM path provided
-                break
-            else
-                echo -e "\033[31mThe provided PHP binary ($PHP_CUSTOM) does not meet the minimum requirements. Please enter the path to a valid one:\033[0m"
+if [ "$BYPASS" == false ]; then
+    php_binary=`find_php`
+    status=$?
+    if [[ $status -eq 0 ]]; then
+        # Found the recommended version, can use current versions
+        frozen=false
+    elif [[ $status -eq 255 ]]; then
+        # Found the minimum required version, stuck on the 'frozen' tier
+        frozen=true
+    fi
+
+    # Request the path to a VALID PHP binary if auto-detect failed
+    if [[ -z "$php_binary" || ! -e "$php_binary" || -d "$php_binary" ]]; then
+        echo ""
+        echo -e "\033[31mUnable to detect your Plesk's PHP binary. Please specify that path manually (must be at least PHP5 $REQUIRED_VERSION), followed by [ENTER]:\033[0m"
+        echo ""
+        read PHP_CUSTOM
+
+        while [[ true ]]; do
+            if [[ -z "$PHP_CUSTOM" || ! -e "$PHP_CUSTOM" || -d "$PHP_CUSTOM" ]]; then
+                echo -e "\033[31mPlease enter a valid path to the PHP5 binary:\033[0m"
                 read PHP_CUSTOM
+            else
+                $(check_php_version "$PHP_CUSTOM" > /dev/null 2>&1)
+                status=$?
+                if [[ $status -eq 0 ]]; then
+                    frozen=false
+                    break
+                elif [[ $status -eq 255 ]]; then
+                    frozen=true
+                    break
+                else
+                    echo -e "\033[31mThe provided PHP binary ($PHP_CUSTOM) does not meet the minimum requirements. Please enter the path to a valid one:\033[0m"
+                    read PHP_CUSTOM
+                fi
+
             fi
+        done
 
-        fi
-    done
+        php_binary=$PHP_CUSTOM
+    fi
 
-    php_binary=$PHP_CUSTOM
+    path_php="$php_binary"
 fi
-
-path_php="$php_binary"
 
 ## Lets check paneltype
 if [ -d "/usr/local/psa" ];
@@ -112,20 +145,28 @@ fi
 
 random=`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c5 | md5sum | awk {'print $1'}`
 
-# check for branch
-if [ -n "$1" ]
-then
-    if [ "trunk" == "$1" ] || [ "master" == "$1" ]
-    then
-        CHECKURL="http://download.seinternal.com/integration/?act=getversion&panel=$paneltype&tier=testing&rand=$random"
-        filepart="_testing.tar.gz"
-    else
-        CHECKURL="http://download.seinternal.com/integration/?act=getversion&panel=$paneltype&tier=testing&rand=$random&branch=$1"
-        filepart="_testing_$1.tar.gz"
-    fi
+# set base path for the url that checks the current version
+basepath="http://download.seinternal.com/integration"
+
+# check if it's restricted to the 'frozen' tier or not
+if [ "$frozen" == true ] || [ "frozen" == "$1" ]; then
+    CHECKURL="$basepath/?act=getversion&panel=$paneltype&tier=frozen&rand=$random"
+    filepart="_frozen.tar.gz"
+    echo -e "\033[33mYou are running an old PHP version no longer actively supported by this addon so only the 'frozen' update tier is available, for critical bugfixes. It is highly recommended to upgrade to a newer PHP version (>=$RECOMMENDED_VERSION) to have access to all the latest features.\033[0m"
 else
-    CHECKURL="http://download.seinternal.com/integration/?act=getversion&panel=$paneltype&tier=stable&rand=$random"
-    filepart="_stable.tar.gz"
+    # check for branch
+    if [ -n "$1" ]; then
+        if [ "trunk" == "$1" ] || [ "master" == "$1" ]; then
+            CHECKURL="$basepath/?act=getversion&panel=$paneltype&tier=testing&rand=$random"
+            filepart="_testing.tar.gz"
+        else
+            CHECKURL="$basepath/?act=getversion&panel=$paneltype&tier=testing&rand=$random&branch=$1"
+            filepart="_testing_$1.tar.gz"
+        fi
+    else
+        CHECKURL="$basepath/?act=getversion&panel=$paneltype&tier=stable&rand=$random"
+        filepart="_stable.tar.gz"
+    fi
 fi
 
 version=`$path_wget -q -O - "$CHECKURL" | sed -e 's/[{}]/''/g' | awk -v RS=',"' -F: '/^data/ {print $3}' |  sed s/\"//g`
@@ -135,7 +176,8 @@ if [ -z "$version" ]; then
     exit 1
 fi
 
-basepath="http://download.seinternal.com/integration/files/$paneltype"
+# update basepath for download files
+basepath="$basepath/files/$paneltype"
 package="v$version"
 fullfile="$package$filepart"
 srcpath="/usr/src/prospamfilter"

--- a/library/SpamFilter/Core.php
+++ b/library/SpamFilter/Core.php
@@ -45,6 +45,8 @@
 class SpamFilter_Core
 {
     const PHP5_BINARY_SYMLINK = '/usr/local/bin/prospamfilter_php';
+    const PHP5_REQUIRED_VERSION = '5.2.1';
+    const PHP5_RECOMMENDED_VERSION = '5.4';
 
     /**
      * getBitType
@@ -61,20 +63,20 @@ class SpamFilter_Core
         return (int)(8 * PHP_INT_SIZE);
     }
 
-	/**
-	 * getConfigBinary
-	 * Return the full path to the getconfig binary
-	 *
+    /**
+     * getConfigBinary
+     * Return the full path to the getconfig binary
+     *
      * @param int $bits Optional override of specific byte-type binary
-	 *
-	 * @return string Path to the getconfig binary
-	 *
-	 * @access public
-	 * @static
-	 * @see getBitType()
-	 */
-	public static function getConfigBinary( $bits = null )
-	{
+     *
+     * @return string Path to the getconfig binary
+     *
+     * @access public
+     * @static
+     * @see getBitType()
+     */
+    public static function getConfigBinary( $bits = null )
+    {
             if(self::isWindows()){
                 $binary = 'getconfig.exe';
                 return trim( BASE_PATH . DS ."bin". DS . $binary);
@@ -95,99 +97,99 @@ class SpamFilter_Core
             return trim( BASE_PATH . "/bin/{$binary}" );
         }
 
-	/**
-	 * isCpanel
-	 * Returns whether the used panel is cPanel
-	 *
-	 *
-	 * @return bool Whether it is cPanel or not
-	 *
-	 * @access public
-	 * @static
-	 * @see getPanelType()
-	 */
-	public static function isCpanel()
-	{
-		$type = strtoupper( self::getPanelType() );
+    /**
+     * isCpanel
+     * Returns whether the used panel is cPanel
+     *
+     *
+     * @return bool Whether it is cPanel or not
+     *
+     * @access public
+     * @static
+     * @see getPanelType()
+     */
+    public static function isCpanel()
+    {
+        $type = strtoupper( self::getPanelType() );
 
-		return ($type == "CPANEL") ? true : false;
-	}
+        return ($type == "CPANEL") ? true : false;
+    }
 
-	/**
-	 * getPanelType
-	 * Returns the panel type
-	 *
-	 *
-	 * @return string Type of panel in use (uppercased)
-	 *
-	 * @access public
-	 * @static
-	 */
-	public static function getPanelType()
-	{
+    /**
+     * getPanelType
+     * Returns the panel type
+     *
+     *
+     * @return string Type of panel in use (uppercased)
+     *
+     * @access public
+     * @static
+     */
+    public static function getPanelType()
+    {
         if (file_exists('/usr/local/psa/') || file_exists($_ENV['plesk_dir'])) {
-			Zend_Registry::get('logger')->debug("[Core] Panel is determined to be Plesk.");
+            Zend_Registry::get('logger')->debug("[Core] Panel is determined to be Plesk.");
 
-			return 'PLESK';
-		}
+            return 'PLESK';
+        }
 
-		Zend_Registry::get('logger')->err("[Core] Paneltype cannot be determined.");
+        Zend_Registry::get('logger')->err("[Core] Paneltype cannot be determined.");
 
-		return 'UNKNOWN';
-	}
+        return 'UNKNOWN';
+    }
 
-	/**
-	 * initLogging
-	 * Initializes logging system
-	 *
+    /**
+     * initLogging
+     * Initializes logging system
+     *
      * @param bool $logging Enable logging or not
      * @param bool $debug   Enable debug-level logging
-	 *
-	 * @return Spamfilter_Logger object
-	 *
-	 * @access public
-	 * @static
-	 */
-	public static function initLogging( $logging = false, $debug = false )
-	{
-		// check if we want $debug
+     *
+     * @return Spamfilter_Logger object
+     *
+     * @access public
+     * @static
+     */
+    public static function initLogging( $logging = false, $debug = false )
+    {
+        // check if we want $debug
         if ($logging) {
-			// Syslog it.
-			$writer = new Zend_Log_Writer_Syslog(
-							array(
-								'application' => 'ProSpamFilter'
-								)
-							);
-		} else {
-			// Use dummy writer
-			$writer = new Zend_Log_Writer_Null();
-		}
+            // Syslog it.
+            $writer = new Zend_Log_Writer_Syslog(
+                            array(
+                                'application' => 'ProSpamFilter'
+                                )
+                            );
+        } else {
+            // Use dummy writer
+            $writer = new Zend_Log_Writer_Null();
+        }
 
         if ($debug) {
-			// Receive DEBUG messages and below
-			$writer->addFilter(new Zend_Log_Filter_Priority( Zend_Log::DEBUG ));
-		} else {
-			// Receive UP TO the DEBUG level of messages.
-			$writer->addFilter(new Zend_Log_Filter_Priority( Zend_Log::CRIT ));
-		}
+            // Receive DEBUG messages and below
+            $writer->addFilter(new Zend_Log_Filter_Priority( Zend_Log::DEBUG ));
+        } else {
+            // Receive UP TO the DEBUG level of messages.
+            $writer->addFilter(new Zend_Log_Filter_Priority( Zend_Log::CRIT ));
+        }
 
-		#$logger = new Zend_Log($writer);
-		$logger = new SpamFilter_Logger( $writer ); //<-- Custom logging function
+        #$logger = new Zend_Log($writer);
+        $logger = new SpamFilter_Logger( $writer ); //<-- Custom logging function
 
-		Zend_Registry::set('logger', $logger);
+        Zend_Registry::set('logger', $logger);
 
-		return $logger;
-	}
+        return $logger;
+    }
 
-	public static function initConfig( $configFile )
-	{
-		$conf = new SpamFilter_Configuration( $configFile );
+    public static function initConfig( $configFile )
+    {
+        $conf = new SpamFilter_Configuration( $configFile );
 
-		return $conf;
-	}
+        return $conf;
+    }
 
     final static public function getUsername()
-	{
+    {
         /** @var $logger SpamFilter_Logger */
         /** @noinspection PhpUndefinedClassInspection */
         $logger = Zend_Registry::get('logger');
@@ -236,22 +238,22 @@ class SpamFilter_Core
         if (isset($_ENV['REMOTE_USER']) && (!empty($_ENV['REMOTE_USER']))) {
             $logger->debug("[Core] Returning username ({$_ENV['REMOTE_USER']}) retrieved from env as remote_user");
 
-			return $_ENV['REMOTE_USER'];
-		} elseif (isset($_SERVER['REMOTE_USER']) && (!empty($_SERVER['REMOTE_USER']))) {
+            return $_ENV['REMOTE_USER'];
+        } elseif (isset($_SERVER['REMOTE_USER']) && (!empty($_SERVER['REMOTE_USER']))) {
             $logger->debug("[Core] Returning username ({$_SERVER['REMOTE_USER']}) retrieved from $_SERVER (REMOTE_USER)");
 
-			return $_SERVER['REMOTE_USER'];
+            return $_SERVER['REMOTE_USER'];
 
         /** @see https://trac.spamexperts.com/ticket/19646 */
         } elseif (!empty($_SERVER['USER']) && 'psaadm' != $_SERVER['USER']) {
             $logger->debug("[Core] Returning username ({$_SERVER['USER']}) retrieved from \$_SERVER['user']");
 
-			return $_SERVER['USER'];
+            return $_SERVER['USER'];
         } elseif (isset($_SERVER['USERNAME']) && (!empty($_SERVER['USERNAME']))) {
             $logger->debug("[Core] Returning username ({$_SERVER['USERNAME']}) retrieved from $_SERVER (username)");
 
-			return $_SERVER['USERNAME'];
-		} elseif (!empty($_SESSION['auth']['isAuthenticatedAsRoot'])) {
+            return $_SERVER['USERNAME'];
+        } elseif (!empty($_SESSION['auth']['isAuthenticatedAsRoot'])) {
             $logger->debug("[Core] Returning username (root) as I see the ['auth']['isAuthenticatedAsRoot'] variable is set in Plesk");
 
             return 'root';
@@ -291,8 +293,8 @@ class SpamFilter_Core
 
         $logger->err("[Core] Unable to retrieve the username.");
 
-		return false;
-	}
+        return false;
+    }
 
     final static public function getDomainsCacheId()
     {
@@ -307,244 +309,244 @@ class SpamFilter_Core
 
     final static public function invalidateDomainsCaches()
     {
-		self::clearCacheWithPrefix('alldomains_');
-		self::clearCacheWithPrefix('user_domains_');
-		SpamFilter_Panel_Cache::clear('collectiondomains');
+        self::clearCacheWithPrefix('alldomains_');
+        self::clearCacheWithPrefix('user_domains_');
+        SpamFilter_Panel_Cache::clear('collectiondomains');
     }
 
-	final static private function clearCacheWithPrefix($prefix = null)
-	{
-		foreach (SpamFilter_Panel_Cache::listMatches("$prefix") as $cacheId) {
-			SpamFilter_Panel_Cache::clear($cacheId, false);
-		}
-	}
+    final static private function clearCacheWithPrefix($prefix = null)
+    {
+        foreach (SpamFilter_Panel_Cache::listMatches("$prefix") as $cacheId) {
+            SpamFilter_Panel_Cache::clear($cacheId, false);
+        }
+    }
 
-	/**
-	 * Checks whether the requirements are met
-	 *
+    /**
+     * Checks whether the requirements are met
+     *
      * @param bool          $fullCheck Execute a full check or just a brief one (defaults to full)     *
      * @param array         $options
-	 *
-	 * @return array Statuscode and error messages.
-	 *
-	 * @access public
-	 * @static
-	 * @see  PanelApiTest()
-	 * @see  isCpanel()
-	 */
-	public static function selfCheck( $fullCheck = true, $options = array() )
-	{
-		$rv = array();
-		$rv['status'] = true;
-		$rv['reason'] = array();
-		$rv['critital'] = false;
+     *
+     * @return array Statuscode and error messages.
+     *
+     * @access public
+     * @static
+     * @see  PanelApiTest()
+     * @see  isCpanel()
+     */
+    public static function selfCheck( $fullCheck = true, $options = array() )
+    {
+        $rv = array();
+        $rv['status'] = true;
+        $rv['reason'] = array();
+        $rv['critital'] = false;
 
-		$obligatoryExtensions = array(
-			'OpenSSL' 		=>	 	'openssl_open',		//Optionally used in API communication
-			'Fopen'  		=> 		'fopen',		//Used in branding regeneration
-			'Curl'   		=> 		'curl_init',		//Used in API communication (software + spampanel API)
-			'Shell_Exec'  		=> 		'shell_exec',		//used in install/upgrade/branding regeneration
-			'system'		=> 		'system',		//used in install/upgrade/branding regeneration
-			'chown'			=>		'chown'			//used in install/upgrade
-		);
+        $obligatoryExtensions = array(
+            'OpenSSL' 		=>	 	'openssl_open',		//Optionally used in API communication
+            'Fopen'  		=> 		'fopen',		//Used in branding regeneration
+            'Curl'   		=> 		'curl_init',		//Used in API communication (software + spampanel API)
+            'Shell_Exec'  		=> 		'shell_exec',		//used in install/upgrade/branding regeneration
+            'system'		=> 		'system',		//used in install/upgrade/branding regeneration
+            'chown'			=>		'chown'			//used in install/upgrade
+        );
 
-		// Check all available PHP functions and return false if we don't have it (which is a problem!)
+        // Check all available PHP functions and return false if we don't have it (which is a problem!)
         foreach ($obligatoryExtensions as $ext => $functionToCheck) {
             if (!function_exists($functionToCheck)) {
-		    	Zend_Registry::get('logger')->emerg("Addon is missing support for {$functionToCheck}");
+                Zend_Registry::get('logger')->emerg("Addon is missing support for {$functionToCheck}");
                 if ($functionToCheck == "openssl_open") {
                     array_push(
                         $rv['reason'],
                         "Missing {$ext} support for PHP. This simply means you cannot use SSL between cPanel and the spamfilter or between the addon and cPanel."
                     );
-		    	} else {
+                } else {
                     if ($functionToCheck <> "openssl_open") {
-						// Everything, except OpenSSL is mandatory.
-						array_push($rv['reason'], "Missing required PHP Module or function: {$ext}. ");
-						$rv['critital'] = true; // We cannot work without these addons.
-					} else {
-						array_push($rv['reason'], "Missing optional PHP Module or function: {$ext}. ");
-					}
-				}
-			#return false;
-		    }
-		}
+                        // Everything, except OpenSSL is mandatory.
+                        array_push($rv['reason'], "Missing required PHP Module or function: {$ext}. ");
+                        $rv['critital'] = true; // We cannot work without these addons.
+                    } else {
+                        array_push($rv['reason'], "Missing optional PHP Module or function: {$ext}. ");
+                    }
+                }
+            #return false;
+            }
+        }
 
-		// Ok, apparently we have all required functions. Now lets check some other info.
+        // Ok, apparently we have all required functions. Now lets check some other info.
         if (version_compare(PHP_VERSION, '5.0.0', '<')) {
-			// This plugin is built for PHP5 (due to OOP), so it shouldn't work when PHP4 is being used.
+            // This plugin is built for PHP5 (due to OOP), so it shouldn't work when PHP4 is being used.
             Zend_Registry::get('logger')->emerg(
                 "PHP version '" . PHP_VERSION . "' is being used instead of required 5.0.0"
             );
-		    	array_push($rv['reason'], "PHP Version < 5.0.0");
-				$rv['critital'] = true; // This is critical enough to be a problem. PHP5 is required, at the very least verson 5.0.0.
-			#return false;
-		}
+                array_push($rv['reason'], "PHP Version < 5.0.0");
+                $rv['critital'] = true; // This is critical enough to be a problem. PHP5 is required, at the very least verson 5.0.0.
+            #return false;
+        }
 
         if ($fullCheck) {
 
-			// Version check of the control panel used.
+            // Version check of the control panel used.
             /** @var $panel SpamFilter_PanelSupport_Plesk */
-			$panel = new SpamFilter_PanelSupport( null, $options );
+            $panel = new SpamFilter_PanelSupport( null, $options );
             if ($panel) {
-				$minVerCheck = $panel->minVerCheck();
+                $minVerCheck = $panel->minVerCheck();
                 if ($minVerCheck) {
-					try {
-						$version = $panel->getVersion();
+                    try {
+                        $version = $panel->getVersion();
                         if (!empty($version)) {
                             @array_push(
                                 $rv['reason'], "Your controlpanel is running an unsupported version. ({$version})"
                             );
-					}
+                    }
                     } catch (Exception $e) {
-						Zend_Registry::get('logger')->err("Error while running version check (reporting error)");
-					}
-				}
-			}
+                        Zend_Registry::get('logger')->err("Error while running version check (reporting error)");
+                    }
+                }
+            }
 
-		} // end fullCheck
+        } // end fullCheck
 
-		// All checks succeeded, very good!
+        // All checks succeeded, very good!
         if (count($rv['reason']) > 0) {
-		    	$rv['status'] = false;
-		}
+                $rv['status'] = false;
+        }
 
-		return $rv;
-	}
+        return $rv;
+    }
 
-	/**
-	 * PanelApiTest
-	 * Tests whether the panel provided API is available
-	 * Actually redirects the request to the specific panel driver.
-	 *
-	 *
-	 * @return bool Status of controlpanel API
-	 *
-	 * @access public
-	 * @static
-	 */
-	public static function PanelApiTest()
-	{
-		// Check if we can communicate with the "foreign" API as well.
+    /**
+     * PanelApiTest
+     * Tests whether the panel provided API is available
+     * Actually redirects the request to the specific panel driver.
+     *
+     *
+     * @return bool Status of controlpanel API
+     *
+     * @access public
+     * @static
+     */
+    public static function PanelApiTest()
+    {
+        // Check if we can communicate with the "foreign" API as well.
 
         /** @var $panel SpamFilter_PanelSupport_Plesk */
-		$panel = new SpamFilter_PanelSupport( );
+        $panel = new SpamFilter_PanelSupport( );
         if (!$panel) {
-			Zend_Registry::get('logger')->err("[PanelApiTest] Not possible to check without panel driver");
+            Zend_Registry::get('logger')->err("[PanelApiTest] Not possible to check without panel driver");
 
-			return false; // cannot check
-		}
+            return false; // cannot check
+        }
 
-		$status = $panel->apiAvailable();
-		Zend_Registry::get('logger')->err("[PanelApiTest] Status: {$status}");
+        $status = $panel->apiAvailable();
+        Zend_Registry::get('logger')->err("[PanelApiTest] Status: {$status}");
 
-		return $status;
-	}
+        return $status;
+    }
 
-	/**
-	 * ApiTest
-	 * Tests whether our API is available
-	 *
-	 *
-	 * @return bool Status of API
-	 *
-	 * @access public
-	 * @static
-	 * @see ApiVersion()
-	 */
-	public static function ApiTest()
-	{
-		$check = self::ApiVersion();
+    /**
+     * ApiTest
+     * Tests whether our API is available
+     *
+     *
+     * @return bool Status of API
+     *
+     * @access public
+     * @static
+     * @see ApiVersion()
+     */
+    public static function ApiTest()
+    {
+        $check = self::ApiVersion();
         if (!empty($check)) {
-			return true;
-		}
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	/**
-	 * ApiVersion
-	 * Returns the version of the API
-	 *
-	 *
-	 * @return string API version
-	 *
-	 * @access public
-	 * @static
-	 * @see getApi()
-	 */
-	public static function ApiVersion()
-	{
-		$api = new SpamFilter_ResellerAPI();
+    /**
+     * ApiVersion
+     * Returns the version of the API
+     *
+     *
+     * @return string API version
+     *
+     * @access public
+     * @static
+     * @see getApi()
+     */
+    public static function ApiVersion()
+    {
+        $api = new SpamFilter_ResellerAPI();
 
-		return $api->version()->get( array() ) ;
-	}
+        return $api->version()->get( array() ) ;
+    }
 
-	/**
-	 * isTesting
-	 * Returns whether testing mode is enabled (only applies on updates)
-	 *
-	 *
-	 * @return bool Whether testing is enabled or disabled.
-	 *
-	 * @access public
-	 * @static
-	 */
-	public static function isTesting()
-	{
+    /**
+     * isTesting
+     * Returns whether testing mode is enabled (only applies on updates)
+     *
+     *
+     * @return bool Whether testing is enabled or disabled.
+     *
+     * @access public
+     * @static
+     */
+    public static function isTesting()
+    {
         if (file_exists(CFG_PATH . "/testing")) {
-			// Manual override
-			return true;
-		}
+            // Manual override
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	/**
-	 * GetServerName
-	 * Returns the FQDN servername, used in routes if required.
-	 *
-	 *
-	 * @return string Hostname of the server
-	 *
-	 * @access public
-	 * @static
-	 */
-	public static function GetServerName()
-	{
-		// Use servername (only works when being called from WEB, not CLI)
+    /**
+     * GetServerName
+     * Returns the FQDN servername, used in routes if required.
+     *
+     *
+     * @return string Hostname of the server
+     *
+     * @access public
+     * @static
+     */
+    public static function GetServerName()
+    {
+        // Use servername (only works when being called from WEB, not CLI)
         if (!empty($_SERVER['SERVER_NAME'])) {
-			return trim( $_SERVER['SERVER_NAME'] );
-		}
+            return trim( $_SERVER['SERVER_NAME'] );
+        }
 
-		// Fallback to a generic method which should provide us what we need.
-		$hostname = trim(shell_exec('hostname -f'));
+        // Fallback to a generic method which should provide us what we need.
+        $hostname = trim(shell_exec('hostname -f'));
         if (!empty($hostname)) {
-			return $hostname;
-		}
+            return $hostname;
+        }
 
-		// Third fallback option, just in case we need that.
-		$hostname = php_uname('n');
+        // Third fallback option, just in case we need that.
+        $hostname = php_uname('n');
         if (!empty($hostname)) {
-			return trim($hostname);
-		}
+            return trim($hostname);
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	/**
-	 * validateDomain
-	 * Validates whether the provided domain is correct or not
-	 *
+    /**
+     * validateDomain
+     * Validates whether the provided domain is correct or not
+     *
      * @param string $domain Domainname to validate
-	 *
-	 * @return bool
-	 *
-	 * @access public
-	 * @static
-	 */
-	public static function validateDomain($domain)
-	{
+     *
+     * @return bool
+     *
+     * @access public
+     * @static
+     */
+    public static function validateDomain($domain)
+    {
         if (!is_scalar($domain)) {
             return false;
         }
@@ -561,7 +563,7 @@ class SpamFilter_Core
         }
 
         return preg_match('~^[A-Z0-9][A-Z0-9_-]*(?:\.[A-Z0-9][A-Z0-9_-]*)+$~i', $domain);
-	}
+    }
 
     /**
      * timePassed
@@ -756,4 +758,20 @@ class SpamFilter_Core
     {
         return stripos(PHP_OS, 'win') === 0;
     }
+
+    /**
+     * This method checks the PHP version the addon is running on
+     * to determine if it is the recommended one or higher
+     * and thus has access to the normal 'stable' and 'testing' tiers,
+     * or a lower one that has to be restricted to the 'frozen' tier
+     *
+     * @static
+     * @access public
+     * @return bool
+     */
+    public static function isRestrictedToFrozenTier()
+    {
+        return (-1 === version_compare(phpversion(), self::PHP5_RECOMMENDED_VERSION));
+    }
+
 }

--- a/library/SpamFilter/Forms/UpdateConfig.php
+++ b/library/SpamFilter/Forms/UpdateConfig.php
@@ -4,51 +4,61 @@ class SpamFilter_Forms_UpdateConfig extends Twitter_Form
     protected $_paneltype;
     public function __construct($options = null)
     {
-		$this->addElementPrefixPath('SpamFilter', 'SpamFilter/');
-		parent::__construct($options);
+        $this->addElementPrefixPath('SpamFilter', 'SpamFilter/');
+        parent::__construct($options);
 
-		$config    = Zend_Registry::get('general_config');
+        $config    = Zend_Registry::get('general_config');
         $translate = Zend_Registry::get('translator');
 
-	    $this->setMethod('post')->setName('forceUpdate');
-		
-		$tier_options			    = array();
-		$tier_options['stable'] 	= $translate->_("Stable builds (release, preferred builds)");
-		$tier_options['testing']	= $translate->_("Testing builds (testing)");
-		$tier_options['trunk'] 		= $translate->_("Trunk builds (unstable)");
+        $this->setMethod('post')->setName('forceUpdate');
 
-		$type = new Zend_Form_Element_Select('update_type');
-		$type->setLabel($translate->_("Tier of addon to install"))
-					->setRequired( true )
-					->setMultiOptions( $tier_options )
-					->setValue( $config->updatetier )
-					->setAttrib('class', 'span4')
-					->setAttrib('title', $translate->_("Tier of addon to install"))
-					->setAttrib('data-content', $translate->_("What type of addon release would you like to install?"));
-		$this->addElement( $type );
-		
-		$force_reinstall = new Zend_Form_Element_Checkbox('force_reinstall');
-		$force_reinstall->setLabel($translate->_('Force a reinstall even if the system is up to date.'))
-							->setAttrib('title', $translate->_("Reinstall addon"))
-  	                        ->setAttrib('data-content', $translate->_("Reinstalls the addon (excluding config)"));
-		$this->addElement( $force_reinstall );		
+        $restrictToFrozen = SpamFilter_Core::isRestrictedToFrozenTier();
+        $tier_options = array();
+        if ($restrictToFrozen) {
+            $tier_options['frozen'] = sprintf(
+                $translate->_("Frozen builds (legacy support for PHP < %s)"),
+                SpamFilter_Core::PHP5_RECOMMENDED_VERSION
+            );
+        } else {
+            $tier_options['stable']  = $translate->_("Stable (preferred, released builds)");
+            $tier_options['testing'] = $translate->_("Testing (optional, master builds)");
+        }
 
-		$submit = new Zend_Form_Element_Submit('submit');
-		$submit->setLabel($translate->_('Click to upgrade'));
-		$submit->setAttrib('class', 'btn btn-primary');
-		$this->addElement( $submit );
+        $type = new Zend_Form_Element_Select('update_type');
+        $type->setLabel($translate->_("Tier of addon to install"))
+            ->setRequired( true )
+            ->setMultiOptions( $tier_options )
+            ->setValue( $config->updatetier )
+            ->setAttrib('class', 'span4')
+            ->setAttrib('title', $translate->_("Tier of addon to install"))
+            ->setAttrib('data-content', $translate->_("What type of addon release would you like to install?"));
+        if ($restrictToFrozen) {
+            $type->setAttrib('readonly', 'readonly');
+        }
+        $this->addElement( $type );
+
+        $force_reinstall = new Zend_Form_Element_Checkbox('force_reinstall');
+        $force_reinstall->setLabel($translate->_('Force a reinstall even if the system is up to date.'))
+                            ->setAttrib('title', $translate->_("Reinstall addon"))
+                            ->setAttrib('data-content', $translate->_("Reinstalls the addon (excluding config)"));
+        $this->addElement( $force_reinstall );
+
+        $submit = new Zend_Form_Element_Submit('submit');
+        $submit->setLabel($translate->_('Click to upgrade'));
+        $submit->setAttrib('class', 'btn btn-primary');
+        $this->addElement( $submit );
 
         $this->setAttrib('enctype', 'multipart/form-data');
         $this->setAttrib('horizontal', 1);
-	}
-	
+    }
+
     public function isValid($data)
     {
         $valid = parent::isValid($data);
  
         foreach ($this->getElements() as $element) {
             if ($element->hasErrors()) 
-			{
+            {
                 $oldClass = $element->getAttrib('class');
                 if (!empty($oldClass)) {
                     $element->setAttrib('class', $oldClass . ' inputerror');

--- a/library/SpamFilter/Updater.php
+++ b/library/SpamFilter/Updater.php
@@ -92,7 +92,7 @@ class SpamFilter_Updater
             throw new RuntimeException("The 'system' function is disabled. Unable to continue the update process.");
         }
 
-        $version   = trim(SpamFilter_Version::getUsedVersion());
+        $version   = trim(SpamFilter_Version::getCurrentVersion());
         $paneltype = strtolower(SpamFilter_Core::getPanelType());
         $tier      = strtolower($tier);
 
@@ -101,6 +101,10 @@ class SpamFilter_Updater
         $path = "/usr/src/prospamfilter/";
         if (SpamFilter_Core::isTesting()) {
             $tier = "testing";
+        }
+
+        if (SpamFilter_Core::isRestrictedToFrozenTier()) {
+            $tier = "frozen";
         }
 
         $logger->info("[Update] Going to update the {$paneltype} addon to v{$version} in tier {$tier}");
@@ -128,8 +132,9 @@ class SpamFilter_Updater
                 }
             }
             $updateLogFile = '/tmp/' . uniqid($updateLogFilePrefix) . '.log';
-            $cmd = 'nohup nice -n 10 /usr/local/prospamfilter/bin/installer/installer.sh'
-                . (($tier <> "stable") ? ' trunk' : '') . ' > ' . $updateLogFile . ' 2>&1 & echo $!';
+            $cmd = 'nohup nice -n 10 /usr/local/prospamfilter/bin/installer/installer.sh -f'
+                . ( $tier == "frozen" ? ' frozen' :
+                    ( ($tier <> "stable") ? ' trunk' : '') ) . ' > ' . $updateLogFile . ' 2>&1 & echo $!';
             $pid = shell_exec($cmd);
         }
 

--- a/library/SpamFilter/Version.php
+++ b/library/SpamFilter/Version.php
@@ -102,8 +102,13 @@ class SpamFilter_Version
             if (SpamFilter_Core::isTesting()) {
                 $tier = "testing";
             }
-            $url = "http://download.seinternal.com/integration/?act=getUpdate&" .
-                   "panel={$paneltype}&tier={$tier}&curver={$version}";
+
+            if (SpamFilter_Core::isRestrictedToFrozenTier()) {
+                $tier = "frozen";
+            }
+
+            $basepath = "http://download.seinternal.com/integration";
+            $url = "{$basepath}/?act=getUpdate&panel={$paneltype}&tier={$tier}&curver={$version}";
 
             /** @noinspection PhpUndefinedClassInspection */
             $json_data = SpamFilter_HTTP::getContent($url);


### PR DESCRIPTION
Older PHP versions are no longer actively supported by this addon
and as such will be restricted to a new `frozen` update tier,
which will only receive new fixes for issues deemed critical.

It is highly recommended to upgrade to a newer PHP version
to have access to all the latest features.
